### PR TITLE
Update dragon hunter wand damage bonus to new summer sweep up value

### DIFF
--- a/src/main/java/com/maxhitcalc/MaxAgainstType.java
+++ b/src/main/java/com/maxhitcalc/MaxAgainstType.java
@@ -306,7 +306,7 @@ public class MaxAgainstType extends MaxHit {
             // Dragonbane, added 5 January 2017 ; OR potentially "new" type since value is different from original, added 25 September 2024
             if(weaponItemName.contains("Dragon hunter"))
             {
-                typeBonusToApply.add(1.2);
+                typeBonusToApply.add(1.4);
             }
 
             // Wilderness, added 26 July 2018


### PR DESCRIPTION
Minor fix to bring dragon hunter wand damage bonus to the latest 40% it got from summer sweep up https://oldschool.runescape.wiki/w/Update:Summer_Sweep_Up:_Combat#Other_Boss_and_PvM-Related_Changes