### PR TITLE
v2.1.2 Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ Sidebar Panel and Settings Panel: <br>
 Any feedback/issues can be made through Github: https://github.com/j-cob44/max-hit-calc/issues <br>
 And suggestions can be left here: https://forms.gle/PnFryFtkSqEZAnaq8 <br>
 
-Jacob Burton (j-cob44), August 2025 <br>
-Version 2.1.1
+Jacob Burton (j-cob44), September 2025 <br>
+Version 2.1.2

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.maxhitcalc'
-version = '2.1.1'
+version = '2.1.2'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/src/main/java/com/maxhitcalc/MaxHit.java
+++ b/src/main/java/com/maxhitcalc/MaxHit.java
@@ -588,12 +588,20 @@ public class MaxHit {
     // Calculate Ranged Max Hit
     protected double calculateRangedMaxHit(Item[] playerEquipment, AttackStyle weaponAttackStyle, int attackStyleID)
     {
+        String weaponItemName = EquipmentItems.getItemNameInGivenSetSlot(client, playerEquipment, EquipmentInventorySlot.WEAPON);
+
         // Calculate Ranged Max Hit
         // Step 1: Calculate effective ranged Strength
         int rangedLevel = client.getBoostedSkillLevel(Skill.RANGED);
         double prayerBonus = getPrayerBonus(weaponAttackStyle);
         int styleBonus = getAttackStyleBonus(weaponAttackStyle, attackStyleID);
         double voidBonus = getVoidRangedBonus(playerEquipment); // default 1;
+
+        // If using the atlatl, calculate with strength instead of ranged
+        if(weaponItemName.contains("atlatl"))
+        {
+            rangedLevel  = client.getBoostedSkillLevel(Skill.STRENGTH);
+        }
 
         double effectiveRangedStrength = Math.floor((Math.floor(rangedLevel * prayerBonus) + styleBonus + 8) * voidBonus);
 
@@ -605,7 +613,7 @@ public class MaxHit {
 
         // Step 3: Bonus damage from special attack and effects
         // Rat Default +10 damage Bonus
-        String weaponItemName = EquipmentItems.getItemNameInGivenSetSlot(client, playerEquipment, EquipmentInventorySlot.WEAPON);
+
         if(weaponItemName.contains("Bone shortbow"))
         {
             maxHit = maxHit + 10;

--- a/src/main/java/com/maxhitcalc/MaxHitCalcOverlay.java
+++ b/src/main/java/com/maxhitcalc/MaxHitCalcOverlay.java
@@ -165,12 +165,22 @@ public class MaxHitCalcOverlay extends OverlayPanel
 
         if (prediction.get(0).equals("melee"))
         {
-            result += prediction.get(1) + " Strength Levels </br>" + prediction.get(2) + " Strength Bonus </br>" + (int)((double)prediction.get(3) * 100) + "% Prayer Bonus";
+            result += prediction.get(1) + " Strength Levels </br>" + prediction.get(2) + " Strength Bonus </br>" + (int)((double)prediction.get(3) * 100) + "% Str. Prayer Bonus";
             return result;
         }
         else if (prediction.get(0).equals("ranged"))
         {
-            result += prediction.get(1) + " Ranged Levels </br>" + prediction.get(2) + " Ranged Strength Bonus </br>" + (int)((double)prediction.get(3) * 100) + "% Prayer Bonus";
+            // Atlatl check
+            if(prediction.get(1).equals(0) && !prediction.get(2).equals(0))
+            {
+                result += prediction.get(2) + " Strength Levels </br>" + prediction.get(3) + " Strength Bonus </br>";
+            }
+            else {
+                result += prediction.get(1) + " Ranged Levels </br>" + prediction.get(3) + " Ranged Strength Bonus </br>";
+            }
+
+            result += (int)((double)prediction.get(4) * 100) + "% Ranged Prayer Bonus";
+
             return result;
         }
         else if (prediction.get(0).equals("magic"))

--- a/src/main/java/com/maxhitcalc/NPCTypeWeakness.java
+++ b/src/main/java/com/maxhitcalc/NPCTypeWeakness.java
@@ -336,6 +336,7 @@ public enum NPCTypeWeakness
     Shadow("Shadow", SpellType.Air, 40),
     ShadowWyrm("Shadow Wyrm", SpellType.Air, 50),
     ShadowSpider("Shadow Spider", SpellType.Air, 40),
+    SkeletalHellhound("Skeletal Hellhound", SpellType.Earth, 35),
     SkeletalWyvern("Skeletal Wyvern", SpellType.Fire, 25),
     Skeleton("Skeleton", SpellType.Earth, 40, true), // normal, mage, brute, fremennik, guard, heavy, hero, thug, champion
     SkeletonHellhound("Skeleton Hellhound", SpellType.Earth, 30),

--- a/src/main/java/com/maxhitcalc/NPCTypeWeakness.java
+++ b/src/main/java/com/maxhitcalc/NPCTypeWeakness.java
@@ -50,7 +50,7 @@ public enum NPCTypeWeakness
     AbyssalPortal("Abyssal Portal", SpellType.Fire, 50),
     AdamantDragon("Adamant Dragon", SpellType.Earth, 50),
     AgrithNaar("Agrith Naar", SpellType.Water, 25),
-    Ahrim("Ahrim", SpellType.Air, 50),
+    Ahrim("Ahrim", SpellType.Air, 50, true),
     AirElemental("Air Elemental", SpellType.Air, 30),
     AkkhasShadow("Akkha's Shadow", SpellType.Air, 60),
     AlbinoBat("Albino Bat", SpellType.Air, 40),
@@ -131,7 +131,7 @@ public enum NPCTypeWeakness
     Delrith("Delrith", SpellType.Water, 15),
     DemonicGorilla("Demonic Gorilla", SpellType.Water, 35),
     DeviantSpectre("Deviant Spectre", SpellType.Air, 30),
-    Dharok("Dharok", SpellType.Air, 50),
+    Dharok("Dharok", SpellType.Air, 50, true),
     DontKnowWhat("Don't Know What", SpellType.Fire, 40),
     Doomion("Doomion", SpellType.Water, 25),
     Drake("Drake", SpellType.Water, 50),
@@ -193,7 +193,7 @@ public enum NPCTypeWeakness
     GreatOlm("Great Olm", SpellType.Earth, 50),
     GreenDragon("Green Dragon", SpellType.Water, 50, true), // Brutal, Baby, and normal blue dragons all have the same %
     GrizzlyBear("Grizzly Bear", SpellType.Fire, 20), // normal and cub
-    Guthan("Guthan", SpellType.Air, 50),
+    Guthan("Guthan", SpellType.Air, 50, true),
     HarpieBugSwarm("Harpie Bug Swarm", SpellType.Fire, 50),
     Hellhound("Hellhound", SpellType.Water, 50),
     Hespori("Hespori", SpellType.Fire, 100),
@@ -237,7 +237,7 @@ public enum NPCTypeWeakness
     Kalrag("Kalrag", SpellType.Fire, 10),
     Kamil("Kamil", SpellType.Fire, 10),
     Karamel("Karamel", SpellType.Fire, 40),
-    Karil("Karil", SpellType.Air, 50),
+    Karil("Karil", SpellType.Air, 50, true),
     KasondeTheCraven("Kasonde the Craven", SpellType.Air, 15),
     KetZek("Ket-Zek", SpellType.Water, 40),
     KetlaTheUnworthy("Ketla the Unworthy", SpellType.Air, 15),
@@ -370,7 +370,7 @@ public enum NPCTypeWeakness
     TheForsakenAssassin("The Forsaken Assassin", SpellType.Air, 15),
     ThermonuclearSmokeDevil("Thermonuclear Smoke Devil", SpellType.Air, 40),
     TokXil("Tok-Xil", SpellType.Water, 40),
-    Torag("Torag", SpellType.Air, 50),
+    Torag("Torag", SpellType.Air, 50, true),
     TormentedDemon("Tormented Demon", SpellType.Water, 30),
     TormentedSoul("Tormented Soul", SpellType.Air, 20),
     Tortoise("Tortoise", SpellType.Earth, 20),
@@ -390,7 +390,7 @@ public enum NPCTypeWeakness
     UriumShade("Urium Shade", SpellType.Air, 40),
     Vardorvis("Vardorvis", SpellType.Fire, 35),
     Venenatis("Venenatis", SpellType.Fire, 40, true), // venenatis and spiderlings
-    Verac("Verac", SpellType.Air, 50),
+    Verac("Verac", SpellType.Air, 50, true),
     // verzik vitur phase 3?
     VespineSoldier("Vespine Soldier", SpellType.Fire, 40),
     Vespula("Vespula", SpellType.Fire, 50),

--- a/src/main/java/com/maxhitcalc/StatChangedMaxHit.java
+++ b/src/main/java/com/maxhitcalc/StatChangedMaxHit.java
@@ -231,9 +231,11 @@ public class StatChangedMaxHit
         return maxHit;
     }
 
-    // Calculate Ranged max hit with chagned stats
+    // Calculate Ranged max hit with changed stats
     protected double calculateRangedMaxHit(Item[] playerEquipment, AttackStyle weaponAttackStyle, int attackStyleID, StatChange[] changedStats)
     {
+        String weaponItemName = EquipmentItems.getItemNameInGivenSetSlot(client, playerEquipment, EquipmentInventorySlot.WEAPON);
+
         // Calculate Ranged Max Hit
         // Step 1: Calculate effective ranged Strength
         int rangedLevel = 1;
@@ -250,6 +252,19 @@ public class StatChangedMaxHit
         int styleBonus = maxHits.getAttackStyleBonus(weaponAttackStyle, attackStyleID);
         double voidBonus = maxHits.getVoidRangedBonus(playerEquipment); // default 1;
 
+        // If using the atlatl, calculate with strength instead of ranged
+        if(weaponItemName.contains("atlatl"))
+        {
+            if(checkIfStatChanged(changedStats, Skill.STRENGTH))
+            {
+                rangedLevel = getChangedStatValue(changedStats, Skill.STRENGTH);
+            }
+            else
+            {
+                rangedLevel  = client.getBoostedSkillLevel(Skill.STRENGTH);
+            }
+        }
+
         double effectiveRangedStrength = Math.floor((Math.floor(rangedLevel * prayerBonus) + styleBonus + 8) * voidBonus);
 
         // Step 2: Calculate the max hit
@@ -260,7 +275,6 @@ public class StatChangedMaxHit
 
         // Step 3: Bonus damage from special attack and effects
         // Rat Default +10 damage Bonus
-        String weaponItemName = EquipmentItems.getItemNameInGivenSetSlot(client, playerEquipment, EquipmentInventorySlot.WEAPON);
         if(weaponItemName.contains("Bone shortbow"))
         {
             maxHit = maxHit + 10;


### PR DESCRIPTION
v2.1.2:
- Fixed Eclipse Atlatl calculations to use Strength level and strength bonus instead of ranged
- Fixed Barrows Brothers type weakness not recognizing partial name in lookup
- Add Skeletal Hellhound spell weakness bonus